### PR TITLE
v1.6 add pentest fury

### DIFF
--- a/labshock/docker-compose.yml
+++ b/labshock/docker-compose.yml
@@ -74,12 +74,15 @@ services:
         ipv4_address: 192.168.3.30
     ports:
       - "2222:22"
+      - "3443:3443"
 
   ids:
     build: ./ids/
     network_mode: host
     restart: unless-stopped
-
+    environment:
+      - TZ=America/New_York
+      
   collector:
     build: ./collector/
     networks:

--- a/labshock/pentest/Dockerfile
+++ b/labshock/pentest/Dockerfile
@@ -1,4 +1,4 @@
-FROM zakharbz/labshock-pentest:v1.0.0
+FROM zakharbz/labshock-pentest:v1.1.0
 
 # entrypoint
 COPY entrypoint.sh /entrypoint.sh
@@ -7,4 +7,5 @@ RUN chmod +x /entrypoint.sh
 # start app
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["/usr/sbin/sshd", "-D"]
+WORKDIR /app
+CMD ["sh", "-c", "nginx -g 'daemon off;' & python3 start.py"]

--- a/labshock/portal/Dockerfile
+++ b/labshock/portal/Dockerfile
@@ -1,1 +1,1 @@
-FROM zakharbz/labshock-portal:v1.0.0
+FROM zakharbz/labshock-portal:v1.1.0


### PR DESCRIPTION
LabShock v1.6 – Pentest Station Upgrade: Pentest Fury

LabShock v1.6 brings serious heat to the Pentest Station. This update introduces Pentest Fury, a built-in offensive module set tailored for ICS/OT networks.

New in Pentest Fury
- Web Attack Framework
- Run basic web-based attacks straight from the Pentest Station. Target login forms, misconfigurations, and outdated services.
- Nmap Module
- Custom wrapper for nmap with presets for ICS reconnaissance. Fast scans, service/version detection, and script support.
- Modbus Module
Read/write coils and registers, simulate unauthorized control actions, and test detection rules with real protocol abuse.