### PR TITLE
Update docker-compose.yml

### DIFF
--- a/oilsprings/docker-compose.yml
+++ b/oilsprings/docker-compose.yml
@@ -51,7 +51,7 @@ networks:
   
 services:
   portal:
-    image: zakharbz/labshock-portal:2.0.0
+    image: zakharbz/labshock-portal:v2.0.0
     volumes:
       - portal-data:/app/config/
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
image was missing a v in version number.

You mention PORTAL_VERSION: 2.0.2 i don't know if you had v2.0.2 in mind instead of v2.0.0 or a more recent version like v2.1.4 (latest release as of writing) or v2.1.6 (latest version available on docker hub)